### PR TITLE
Set Go package option pointing to generated SDK

### DIFF
--- a/buf/knit/gateway/v1alpha1/knit.proto
+++ b/buf/knit/gateway/v1alpha1/knit.proto
@@ -4,6 +4,8 @@ package buf.knit.gateway.v1alpha1;
 
 import "google/protobuf/struct.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/knit/protocolbuffers/go/buf/knit/gateway/v1alpha1";
+
 // The top level request definition.
 //
 // It contains an entry point method to be executed along with

--- a/buf/knit/v1alpha1/options.proto
+++ b/buf/knit/v1alpha1/options.proto
@@ -4,6 +4,8 @@ package buf.knit.v1alpha1;
 
 import "google/protobuf/descriptor.proto";
 
+option go_package = "buf.build/gen/go/bufbuild/knit/protocolbuffers/go/buf/knit/v1alpha1";
+
 extend google.protobuf.MethodOptions {
   // Configuration for the relation that this method resolves. Should only be
   // present for methods that resolve a Knit relation.


### PR DESCRIPTION
The [`github.com/bufbuild/knit-go`](https://pkg.go.dev/github.com/bufbuild/knit-go?tab=imports) package uses this import path, so this seems like the canonical Go import path that should be documented in the proto itself. This is also consistent with the option in [`protovalidate`](https://github.com/bufbuild/protovalidate/blob/main/proto/protovalidate/buf/validate/validate.proto#L25C1-L25C95).

We may want to update the breaking change detection logic in `buf` to allow changing a Go package from empty to non-empty, because the Go plugin will not actually generate any code if it's empty. So previously (with no option), users had to provide a `-M` option to the plugin in order to actually import this file and generate Go code. So setting the package now should not actually break anyone.