### PR TITLE
Temporarily disable "buf breaking"

### DIFF
--- a/.github/workflows/buf.yaml
+++ b/.github/workflows/buf.yaml
@@ -8,21 +8,21 @@ jobs:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1
       - uses: bufbuild/buf-lint-action@v1.0.3
-  breaking:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: bufbuild/buf-setup-action@v1
-      - uses: bufbuild/buf-breaking-action@v1.1.2
-        with:
-          against: buf.build/bufbuild/knit
+#  breaking:
+#    runs-on: ubuntu-20.04
+#    steps:
+#      - uses: actions/checkout@v3
+#      - uses: bufbuild/buf-setup-action@v1
+#      - uses: bufbuild/buf-breaking-action@v1.1.2
+#        with:
+#          against: buf.build/bufbuild/knit
   push:
     environment: production
     runs-on: ubuntu-20.04
     if: github.ref == 'refs/heads/main'
     needs:
       - lint
-      - breaking
+#      - breaking
     steps:
       - uses: actions/checkout@v3
       - uses: bufbuild/buf-setup-action@v1


### PR DESCRIPTION
This is needed in order to push the recent change to the Go package, which `buf breaking` considers to be a breaking change. However, the Go plugin refuses to generate code that has no Go package unless the user provides a `-M` option. So all users generating Go code for these files are already using `-M` or are using something like Buf's "managed mode", which means changing this option from empty to non-empty won't actually break anyone in practice.

After the changes are pushed to the BSR, we can undo this change and re-enable the check.